### PR TITLE
Changed "Bundle" to "Plugin".

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ http://www.nickcoleman.org/
 If you are using Vundle, just add the following line to your .vimrc:
 
 ```
-Bundle 'beloglazov/vim-online-thesaurus'
+Plugin 'beloglazov/vim-online-thesaurus'
 ```
 
-Then run `:BundleInstall` to install the plugin.
+Then run `:PluginInstall` to install the plugin.
+
+Note: Earlier versions required the "Bundle" keyword instead of plugin (i.e. :BundleInstall
+and Bundle 'beloglazov/vim-online-thesaurus'). However,
+this is deprecated and should not be used any longer.
 
 
 ## Usage


### PR DESCRIPTION
Vundle has deprecated the word "Bundle". See
https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L372-L396
