### PR TITLE
Fixed broken URL 

### DIFF
--- a/plugin/thesaurus-lookup.sh
+++ b/plugin/thesaurus-lookup.sh
@@ -5,7 +5,7 @@
 # Version:      0.1.7
 # Original idea and code: Nick Coleman <http://www.nickcoleman.org/>
 
-URL="http://thesaurus.com/browse/${1}"
+URL="http://www.thesaurus.com/browse/${1}"
 
 if [ "$(uname)" = "FreeBSD" ]; then
         DOWNLOAD="fetch"


### PR DESCRIPTION
Thesaurus.com gives a 302 moved permanently if accessed without www.!
