### PR TITLE
Fix issue with thesaurus window reuse

### DIFF
--- a/plugin/online-thesaurus.vim
+++ b/plugin/online-thesaurus.vim
@@ -18,7 +18,7 @@ silent let s:sort = system('if command -v /bin/sort > /dev/null; then'
             \ . ' else echo -n sort; fi')
 
 function! s:Lookup(word)
-    let l:thesaurus_window = bufwinnr('thesaurus')
+    let l:thesaurus_window = bufwinnr('^thesaurus$')
 
     if l:thesaurus_window > -1
         exec l:thesaurus_window . "wincmd w"


### PR DESCRIPTION
bufwinnr() uses the argument as a file-pattern rather than exact name.
Therefore, for example, when the online-thesaurus help file is open and you try to search for a synonym, an error is thrown.