### PR TITLE
Fix an error raised when only one synonym is available

### DIFF
--- a/plugin/online-thesaurus.vim
+++ b/plugin/online-thesaurus.vim
@@ -34,7 +34,7 @@ function! s:Lookup(word)
     exec ":silent 0r !" . s:path . "/thesaurus-lookup.sh " . shellescape(l:word)
     exec ":silent g/\\vrelevant-\\d+/,/^$/!" . s:sort . " -t ' ' -k 1,1r -k 2,2"
     silent g/\vrelevant-\d+ /s///
-    silent g/^Synonyms/+;/^$/-2s/$\n/, /
+    silent! g/^Synonyms/+;/^$/-2s/$\n/, /
     silent g/^Synonyms:/ normal! JVgq
     0
     exec 'resize ' . (line('$') - 1)


### PR DESCRIPTION
This line joins all the synonyms with a comma separator. When there's only a single synonym, it fails. No worries and doesn't break anything else. Just ignoring.