### PR TITLE
Changed shell from sh to bash

### DIFF
--- a/plugin/thesaurus-lookup.sh
+++ b/plugin/thesaurus-lookup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Vim plugin for looking up words in an online thesaurus
 # Author:       Anton Beloglazov <http://beloglazov.info/>


### PR DESCRIPTION
On my system (Ubuntu 12.04 LTS), "sh" will result in the use of "dash". However, changeset 48372a42e59e8c9db95c64839e9562ec40b77569 introduced a substitution on line 8, which is not supported by dash, resulting
in an error message.

If the shell is changed to bash (which should be available on every system), everything works fine.