### PR TITLE
Fix shell compatibility by using basic sh capabilities

### DIFF
--- a/plugin/online-thesaurus.vim
+++ b/plugin/online-thesaurus.vim
@@ -10,6 +10,8 @@ let g:loaded_online_thesaurus = 1
 
 let s:save_cpo = &cpo
 set cpo&vim
+let s:save_shell = &shell
+let &shell = '/bin/sh'
 
 let s:path = shellescape(expand("<sfile>:p:h"))
 
@@ -55,3 +57,4 @@ command! OnlineThesaurusLookup :call <SID>Lookup(expand('<cword>'))
 command! -nargs=1 Thesaurus :call <SID>Lookup(<q-args>)
 
 let &cpo = s:save_cpo
+let &shell = s:save_shell

--- a/plugin/thesaurus-lookup.sh
+++ b/plugin/thesaurus-lookup.sh
@@ -1,11 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Vim plugin for looking up words in an online thesaurus
 # Author:       Anton Beloglazov <http://beloglazov.info/>
 # Version:      0.2.1
 # Original idea and code: Nick Coleman <http://www.nickcoleman.org/>
 
-URL="http://www.thesaurus.com/browse/${1/ /+}"
+URL="http://www.thesaurus.com/browse/$(echo $1 | tr ' ' '+')"
 
 if [ "$(uname)" = "FreeBSD" ]; then
         DOWNLOAD="fetch"


### PR DESCRIPTION
@Shurakai makes a good point in #22 that the variable substitution introduced lately isn't working on not bash-compatible shells.
But, I don't really agree with the fix of changing sh to bash, because bash isn't available on every system by default (e.g. FreeBSD, OpenBSD, and maybe the rest of the BSDs).

This PR fixes the substitution by using sh capabilities only, and fixes another bug I've found when using vim with tcsh.

Checked on:
* Archlinux with several shells (zsh, tcsh, mksh)
* FreeBSD (tcsh)
* OpenBSD (pdksh)