### PR TITLE
Prevent bufwinnr() from showing an error message

### DIFF
--- a/plugin/online-thesaurus.vim
+++ b/plugin/online-thesaurus.vim
@@ -20,7 +20,7 @@ silent let s:sort = system('if command -v /bin/sort > /dev/null; then'
             \ . ' else printf sort; fi')
 
 function! s:Lookup(word)
-    let l:thesaurus_window = bufwinnr('^thesaurus$')
+    silent! let l:thesaurus_window = bufwinnr('^thesaurus$')
 
     if l:thesaurus_window > -1
         exec l:thesaurus_window . "wincmd w"


### PR DESCRIPTION
When 'debug' is set, bufwinnr() displays an error message
saying the thesaurus buffer is missing if the thesaurus window
is closed.
According to the documentation, this function returns -1 when
a buffer's window can't be found.
This value is checked for and acted upon properly,
so there is no need for that error message, especially
when it bothers people (#25)