### PR TITLE
Fixed unrecognized PartOfSpeech

### DIFF
--- a/plugin/thesaurus-lookup.sh
+++ b/plugin/thesaurus-lookup.sh
@@ -34,7 +34,7 @@ fi
 if ! grep -q 'no thesaurus results' "$OUTFILE" && grep -q 'html' "$OUTFILE"; then
     awk -F'<|>|&quot;' '/synonym-description">/,/filter-[0-9]+/ {
         if (index($0, "txt\">"))
-            printf "\nDefinition: %s", $3
+            printf "\nDefinition: %s.", $3
         else if (index($0, "ttl\">"))
             printf " %s\nSynonyms:\n", $3
         else if (index($0, "thesaurus.com"))

--- a/syntax/thesaurus.vim
+++ b/syntax/thesaurus.vim
@@ -12,19 +12,15 @@ syntax case match
 setlocal iskeyword+=:
 
 " Entry name rules
-syntax match thesMainEntry /Main entry: */ contained
 syntax keyword thesDefinition Definition:
 syntax keyword thesSynonyms Synonyms:
-syntax keyword thesPartOfSpeech noun pron verb adj adv prep conj interj
+syntax match thesPartOfSpeech '\v\a{,6}\.'
 
 " Entry contents rules
-syntax region thesMainWord start=/Main entry:/  end=/$/ contains=CONTAINED keepend
 
 " Highlighting
-hi link thesMainEntry   Keyword
 hi link thesDefinition  Keyword
 hi link thesSynonyms    Keyword
-hi thesMainWord         term=bold cterm=bold gui=bold
 hi thesPartOfSpeech     term=italic cterm=italic gui=italic
 
 let b:current_syntax = "thesaurus"


### PR DESCRIPTION
It's a minor fix. `thesPartOfSpeech` is currently not correctly recognized, hence not displayed `italic`. So I made a minor change to fix it.
Also, `thesMainEntry` is no longer relevant, hence I removed it in the fix.