### PR TITLE
Don't try to name a file until we setup buffer

### DIFF
--- a/plugin/online-thesaurus.vim
+++ b/plugin/online-thesaurus.vim
@@ -46,12 +46,12 @@ function! s:Lookup(word)
     if l:thesaurus_window > -1
         exec l:thesaurus_window . "wincmd w"
     else
-        exec ":silent keepalt belowright split thesaurus:\\ " . l:word_fname
+        silent keepalt belowright new
     endif
-    exec ":silent file thesaurus:\\ " . l:word_fname
 
     setlocal noswapfile nobuflisted nospell nowrap modifiable
     setlocal buftype=nofile bufhidden=hide
+    exec "silent file thesaurus:\\ " . l:word_fname
     1,$d
     echo "Requesting thesaurus.com to look up \"" . l:word . "\"..."
     exec ":silent 0r !" . s:path . " " . shellescape(l:word)


### PR DESCRIPTION
Fixes 'Found a swap file by the name ".thesaurus% hello.swp"'

Sometimes I get swap file messages about the current buffer having a
swap when using :Thesaurus. This prevents those errors by avoiding
naming the buffer name until after its swap and backing file are
disabled.